### PR TITLE
Alex mobs taggify

### DIFF
--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/alligator_snapping_turtle.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/alligator_snapping_turtle.json
@@ -6,7 +6,7 @@
       "alligator_snapping_turtle": {
         "inputs": [
           {
-            "item": "minecraft:cod"
+            "tag": "alexsmobs:alligator_snapping_turtle_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/anaconda.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/anaconda.json
@@ -6,10 +6,7 @@
       "anaconda": {
         "inputs": [
           {
-            "item": "minecraft:chicken"
-          },
-          {
-            "item": "minecraft:cooked_chicken"
+            "tag": "alexsmobs:anaconda_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/anteater.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/anteater.json
@@ -6,7 +6,7 @@
       "anteater": {
         "inputs": [
           {
-            "item": "alexsmobs:leafcutter_ant_pupa"
+            "tag": "alexsmobs:anteater_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/banana_slug.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/banana_slug.json
@@ -6,7 +6,7 @@
       "banana_slug": {
         "inputs": [
           {
-            "item": "minecraft:brown_mushroom"
+            "tag": "alexsmobs:banana_slug_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/bison.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/bison.json
@@ -6,7 +6,7 @@
       "bison": {
         "inputs": [
           {
-            "item": "minecraft:wheat"
+            "tag": "alexsmobs:bison_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/blue_jay.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/blue_jay.json
@@ -6,7 +6,7 @@
       "blue_jay": {
         "inputs": [
           {
-            "tag": "alexsmobs:insect_items"
+            "tag": "alexsmobs:blue_jay_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/caiman.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/caiman.json
@@ -6,15 +6,12 @@
       "caiman": {
         "inputs": [
           {
-            "item": "alexsmobs:raw_catfish"
-          },
-          {
-            "item": "alexsmobs:cooked_catfish"
+            "tag": "alexsmobs:caiman_breedables"
           }
         ],
         "outputs": [
           {
-            "item": "alexmobs:caiman_egg",
+            "item": "alexsmobs:caiman_egg",
             "amount": {
               "min": 1,
               "max": 4

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/capuchin_monkey.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/capuchin_monkey.json
@@ -6,7 +6,7 @@
       "capuchin_monkey": {
         "inputs": [
           {
-            "tag": "alexsmobs:insect_items"
+            "tag": "alexsmobs:capuchin_monkey_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/cockroach.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/cockroach.json
@@ -6,7 +6,7 @@
       "cockroach": {
         "inputs": [
           {
-            "item": "minecraft:sugar"
+            "tag": "alexsmobs:cockroach_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/cosmaw.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/cosmaw.json
@@ -6,7 +6,7 @@
       "cosmaw": {
         "inputs": [
           {
-            "item": "alexsmobs:cosmic_cod"
+            "tag": "alexsmobs:cosmaw_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/crocodile.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/crocodile.json
@@ -6,12 +6,12 @@
       "crocodile": {
         "inputs": [
           {
-            "item": "minecraft:rotten_flesh"
+            "tag": "alexsmobs:crocodile_breedables"
           }
         ],
         "outputs": [
           {
-            "item": "alexmobs:crocodile_egg"
+            "item": "alexsmobs:crocodile_egg"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/crow.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/crow.json
@@ -6,7 +6,7 @@
       "crow": {
         "inputs": [
           {
-            "item": "minecraft:pumpkin_seeds"
+            "tag": "alexsmobs:crow_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/elephant.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/elephant.json
@@ -6,7 +6,7 @@
       "elephant": {
         "inputs": [
           {
-            "item": "alexsmobs:acacia_blossom"
+            "tag": "alexsmobs:elephant_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/emu.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/emu.json
@@ -6,7 +6,7 @@
       "emu": {
         "inputs": [
           {
-            "item": "minecraft:wheat"
+            "tag": "alexsmobs:emu_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/endergrade.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/endergrade.json
@@ -6,7 +6,7 @@
       "endergrade": {
         "inputs": [
           {
-            "item": "minecraft:chorus_fruit"
+            "tag": "alexsmobs:endergrade_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/flutter.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/flutter.json
@@ -6,7 +6,7 @@
       "flutter": {
         "inputs": [
           {
-            "item": "minecraft:bone_meal"
+            "tag": "alexsmobs:flutter_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/fly.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/fly.json
@@ -6,7 +6,7 @@
       "fly": {
         "inputs": [
           {
-            "item": "minecraft:rotten_flesh"
+            "tag": "alexsmobs:fly_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/froststalker.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/froststalker.json
@@ -6,10 +6,7 @@
       "froststalker": {
         "inputs": [
           {
-            "item": "minecraft:porkchop"
-          },
-          {
-            "item": "minecraft:cooked_porkchop"
+            "tag": "alexsmobs:froststalker_breedables"
           }
         ],
         "extra_inputs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/gazelle.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/gazelle.json
@@ -6,10 +6,7 @@
       "gazelle": {
         "inputs": [
           {
-            "item": "alexsmobs:acacia_blossom"
-          },
-          {
-            "item": "minecraft:wheat"
+            "tag": "alexsmobs:gazelle_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/gelada_monkey.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/gelada_monkey.json
@@ -6,7 +6,7 @@
       "gelada_monkey": {
         "inputs": [
           {
-            "item": "minecraft:dead_bush"
+            "tag": "alexsmobs:gelada_monkey_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/gorilla.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/gorilla.json
@@ -6,7 +6,7 @@
       "gorilla": {
         "inputs": [
           {
-            "tag": "alexsmobs:bananas"
+            "tag": "alexsmobs:gorilla_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/grizzly_bear.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/grizzly_bear.json
@@ -6,7 +6,7 @@
       "grizzly_bear": {
         "inputs": [
           {
-            "item": "minecraft:salmon"
+            "tag": "alexsmobs:grizzly_bear_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/hummingbird.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/hummingbird.json
@@ -6,7 +6,7 @@
       "hummingbird": {
         "inputs": [
           {
-            "tag": "minecraft:flowers"
+            "tag": "alexsmobs:hummingbird_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/jerboa.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/jerboa.json
@@ -6,7 +6,7 @@
       "jerboa": {
         "inputs": [
           {
-            "tag": "alexsmobs:insect_items"
+            "tag": "alexsmobs:jerboa_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/kangaroo.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/kangaroo.json
@@ -6,10 +6,7 @@
       "kangaroo": {
         "inputs": [
           {
-            "item": "minecraft:dead_bush"
-          },
-          {
-            "item": "minecraft:grass"
+            "tag": "alexsmobs:kangaroo_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/komodo_dragon.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/komodo_dragon.json
@@ -6,7 +6,7 @@
       "komodo_dragon": {
         "inputs": [
           {
-            "item": "minecraft:rotten_flesh"
+            "tag": "alexsmobs:komodo_dragon_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/laviathan.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/laviathan.json
@@ -6,7 +6,7 @@
       "laviathan": {
         "inputs": [
           {
-            "item": "alexsmobs:mosquito_larva"
+            "tag": "alexsmobs:laviathan_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/maned_wolf.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/maned_wolf.json
@@ -6,16 +6,7 @@
       "maned_wolf": {
         "inputs": [
           {
-            "item": "minecraft:chicken"
-          },
-          {
-            "item": "minecraft:cooked_chicken"
-          },
-          {
-            "item": "minecraft:cooked_rabbit"
-          },
-          {
-            "item": "minecraft:rabbit"
+            "tag": "alexsmobs:maned_wolf_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/mimic_octopus.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/mimic_octopus.json
@@ -6,7 +6,7 @@
       "mimic_octopus": {
         "inputs": [
           {
-            "item": "minecraft:tropical_fish"
+            "tag": "alexsmobs:mimic_octopus_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/moose.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/moose.json
@@ -6,7 +6,7 @@
       "moose": {
         "inputs": [
           {
-            "item": "minecraft:dandelion"
+            "tag": "alexsmobs:moose_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/mudskipper.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/mudskipper.json
@@ -6,13 +6,7 @@
       "mudskipper": {
         "inputs": [
           {
-            "item": "alexsmobs:cooked_lobster_tail"
-          },
-          {
-            "item": "alexsmobs:lobster_tail"
-          },
-          {
-            "tag": "alexsmobs:insect_items"
+            "tag": "alexsmobs:mudskipper_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/mungus.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/mungus.json
@@ -6,7 +6,7 @@
       "mungus": {
         "inputs": [
           {
-            "item": "alexsmobs:mungal_spores"
+            "tag": "alexsmobs:mungus_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/orca.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/orca.json
@@ -6,7 +6,7 @@
       "orca": {
         "inputs": [
           {
-            "item": "minecraft:salmon"
+            "tag": "alexsmobs:orca_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/platypus.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/platypus.json
@@ -6,15 +6,12 @@
       "platypus": {
         "inputs": [
           {
-            "item": "alexsmobs:cooked_lobster_tail"
-          },
-          {
-            "item": "alexsmobs:lobster_tail"
+            "tag": "alexsmobs:platypus_breedables"
           }
         ],
         "outputs": [
           {
-            "item": "alexmobs:platypus_egg"
+            "item": "alexsmobs:platypus_egg"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/potoo.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/potoo.json
@@ -6,7 +6,7 @@
       "potoo": {
         "inputs": [
           {
-            "tag": "alexsmobs:insect_items"
+            "tag": "alexsmobs:potoo_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/raccoon.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/raccoon.json
@@ -6,7 +6,7 @@
       "raccoon": {
         "inputs": [
           {
-            "item": "minecraft:bread"
+            "tag": "alexsmobs:raccoon_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/rain_frog.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/rain_frog.json
@@ -6,7 +6,7 @@
       "rain_frog": {
         "inputs": [
           {
-            "tag": "alexsmobs:insect_items"
+            "tag": "alexsmobs:rain_frog_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/rhinoceros.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/rhinoceros.json
@@ -6,10 +6,7 @@
       "rhinoceros": {
         "inputs": [
           {
-            "item": "minecraft:dead_bush"
-          },
-          {
-            "item": "minecraft:grass"
+            "tag": "alexsmobs:rhinoceros_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/roadrunner.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/roadrunner.json
@@ -6,7 +6,7 @@
       "roadrunner": {
         "inputs": [
           {
-            "tag": "alexsmobs:insect_items"
+            "tag": "alexsmobs:roadrunner_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/seagull.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/seagull.json
@@ -6,7 +6,7 @@
       "seagull": {
         "inputs": [
           {
-            "item": "minecraft:cod"
+            "tag": "alexsmobs:seagull_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/seal.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/seal.json
@@ -6,7 +6,7 @@
       "seal": {
         "inputs": [
           {
-            "item": "alexsmobs:lobster_tail"
+            "tag": "alexsmobs:seal_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/skunk.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/skunk.json
@@ -6,7 +6,7 @@
       "skunk": {
         "inputs": [
           {
-            "item": "minecraft:sweet_berries"
+            "tag": "alexsmobs:skunk_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/snow_leopard.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/snow_leopard.json
@@ -6,10 +6,7 @@
       "snow_leopard": {
         "inputs": [
           {
-            "item": "alexsmobs:cooked_moose_ribs"
-          },
-          {
-            "item": "alexsmobs:moose_ribs"
+            "tag": "alexsmobs:snow_leopard_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/sugar_glider.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/sugar_glider.json
@@ -6,7 +6,7 @@
       "sugar_glider": {
         "inputs": [
           {
-            "item": "minecraft:honeycomb"
+            "tag": "alexsmobs:sugar_glider_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/tarantula_hawk.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/tarantula_hawk.json
@@ -14,7 +14,7 @@
         ],
         "inputs": [
           {
-            "item": "minecraft:fermented_spider_eye"
+            "tag": "alexsmobs:tarantula_hawk_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/terrapin.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/terrapin.json
@@ -6,12 +6,12 @@
       "terrapin": {
         "inputs": [
           {
-            "item": "minecraft:seagrass"
+            "tag": "alexsmobs:terrapin_breedables"
           }
         ],
         "outputs": [
           {
-            "item": "alexmobs:terrapin_egg",
+            "item": "alexsmobs:terrapin_egg",
             "amount": {
               "min": 1,
               "max": 4

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/toucan.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/toucan.json
@@ -6,7 +6,7 @@
       "toucan": {
         "inputs": [
           {
-            "item": "minecraft:egg"
+            "tag": "alexsmobs:toucan_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/tusklin.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/tusklin.json
@@ -6,7 +6,7 @@
       "tusklin": {
         "inputs": [
           {
-            "item": "minecraft:red_mushroom"
+            "tag": "alexsmobs:tusklin_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/warped_toad.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/breeding/alexsmobs/warped_toad.json
@@ -6,7 +6,7 @@
       "warped_toad": {
         "inputs": [
           {
-            "item": "alexsmobs:mosquito_larva"
+            "tag": "alexsmobs:warped_toad_breedables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/capuchin_monkey.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/capuchin_monkey.json
@@ -6,7 +6,7 @@
       "capuchin_monkey": {
         "inputs": [
           {
-            "tag": "alexsmobs:bananas"
+            "tag": "alexsmobs:capuchin_monkey_tameables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/crow.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/crow.json
@@ -6,7 +6,7 @@
       "crow": {
         "inputs": [
           {
-            "item": "minecraft:pumpkin_seeds"
+            "tag": "alexsmobs:crow_tameables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/elephant.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/elephant.json
@@ -6,7 +6,7 @@
       "elephant": {
         "inputs": [
           {
-            "item": "alexsmobs:acacia_blossom"
+            "tag": "alexsmobs:elephant_tameables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/gorilla.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/gorilla.json
@@ -6,7 +6,7 @@
       "gorilla": {
         "inputs": [
           {
-            "tag": "alexsmobs:bananas"
+            "tag": "alexsmobs:gorilla_tameables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/grizzly_bear.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/grizzly_bear.json
@@ -6,7 +6,7 @@
       "grizzly_bear": {
         "extra_inputs": [
           {
-            "item": "minecraft:salmon"
+            "tag": "alexsmobs:grizzly_tameables"
           }
         ],
         "inputs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/kangaroo.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/kangaroo.json
@@ -3,15 +3,15 @@
   "mod": "alexsmobs",
   "mobs": [
     {
-      "cosmaw": {
+      "kangaroo": {
         "inputs": [
           {
-            "tag": "alexsmobs:cosmaw_tameables"
+            "tag": "alexsmobs:kangaroo_tameables"
           }
         ],
         "spawn_eggs": [
           {
-            "item": "alexsmobs:spawn_egg_cosmaw"
+            "item": "alexsmobs:spawn_egg_kangaroo"
           }
         ]
       }

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/komodo_dragon.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/komodo_dragon.json
@@ -6,7 +6,7 @@
       "komodo_dragon": {
         "inputs": [
           {
-            "item": "minecraft:rotten_flesh"
+            "tag": "alexsmobs:komodo_dragon_tameables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/raccoon.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/raccoon.json
@@ -6,7 +6,7 @@
       "raccoon": {
         "inputs": [
           {
-            "item": "minecraft:egg"
+            "tag": "alexsmobs:raccoon_tameables"
           }
         ],
         "spawn_eggs": [

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/sugar_glider.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/sugar_glider.json
@@ -3,15 +3,15 @@
   "mod": "alexsmobs",
   "mobs": [
     {
-      "cosmaw": {
+      "sugar_glider": {
         "inputs": [
           {
-            "tag": "alexsmobs:cosmaw_tameables"
+            "tag": "alexsmobs:sugar_glider_tameables"
           }
         ],
         "spawn_eggs": [
           {
-            "item": "alexsmobs:spawn_egg_cosmaw"
+            "item": "alexsmobs:spawn_egg_sugar_glider"
           }
         ]
       }

--- a/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/tarantula_hawk.json
+++ b/forge/src/main/resources/data/justenoughbreeding/recipes/taming/alexsmobs/tarantula_hawk.json
@@ -3,15 +3,15 @@
   "mod": "alexsmobs",
   "mobs": [
     {
-      "cosmaw": {
+      "tarantula_hawk": {
         "inputs": [
           {
-            "tag": "alexsmobs:cosmaw_tameables"
+            "tag": "alexsmobs:tarantula_hawk_tameables"
           }
         ],
         "spawn_eggs": [
           {
-            "item": "alexsmobs:spawn_egg_cosmaw"
+            "item": "alexsmobs:spawn_egg_tarantula_hawk"
           }
         ]
       }


### PR DESCRIPTION
Alex's Mobs are well-architected to run off tags rather than specific items. Switching to using the tags means that everything will Just Work for modpacks that change the required items.

Also adds some taming info for a few missing species.